### PR TITLE
update psysh version to fit new hyperf requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tradzero/gokure-hyperf-tinker",
+    "name": "gokure/hyperf-tinker",
     "description": "A Powerful REPL for the Hyperf framework.",
     "keywords": ["hyperf", "tinker", "repl", "psysh"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gokure/hyperf-tinker",
+    "name": "tradzero/gokure-hyperf-tinker",
     "description": "A Powerful REPL for the Hyperf framework.",
     "keywords": ["hyperf", "tinker", "repl", "psysh"],
     "license": "MIT",
@@ -15,7 +15,7 @@
         "hyperf/contract": "~3.0.0 || ~3.1.0",
         "hyperf/di": "~3.0.0 || ~3.1.0",
         "hyperf/command": "~3.0.0 || ~3.1.0",
-        "psy/psysh": "^0.10.6 || ^0.11.1"
+        "psy/psysh": "^0.10.6 || ^0.12.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.6",


### PR DESCRIPTION
hyperf new version(v3.1.42) upgraded symfony/console, and psy/psysh[v0.10.6, ..., v0.10.12] require symfony/console ~5.0|~4.0|~3.0|^2.4.2|~2.3.10. i upgrade psysh version to fit this requirement.